### PR TITLE
WIP attempt to get assets to normalize their timecode to 0 based for AVFoundation

### DIFF
--- a/Sources/OpenTimelineIO-AVFoundation/OpenTimelineIO-Extensions/Clip.swift
+++ b/Sources/OpenTimelineIO-AVFoundation/OpenTimelineIO-Extensions/Clip.swift
@@ -26,9 +26,16 @@ extension Clip
         let rangeInParent = try self.rangeInParent().toCMTimeRange()
 
         // if we have timecode from our asset
-        if let timecodeCMTime = try asset.startTimecode()?.cmTimeValue
+        do
         {
-            timeRangeInAsset = CMTimeRange(start: timeRangeInAsset.start - timecodeCMTime, duration: timeRangeInAsset.duration )
+            if let timecodeCMTime = try asset.startTimecode()?.cmTimeValue
+            {
+                timeRangeInAsset = CMTimeRange(start: timeRangeInAsset.start - timecodeCMTime, duration: timeRangeInAsset.duration )
+            }
+        }
+        catch Timecode.MediaParseError.missingOrNonStandardFrameRate
+        {
+            // not an error
         }
         
         return (asset, CMTimeMapping(source: timeRangeInAsset, target:rangeInParent))

--- a/Sources/OpenTimelineIO-AVFoundation/OpenTimelineIO-Extensions/Clip.swift
+++ b/Sources/OpenTimelineIO-AVFoundation/OpenTimelineIO-Extensions/Clip.swift
@@ -9,7 +9,7 @@ import Foundation
 import CoreMedia
 import AVFoundation
 import OpenTimelineIO
-
+import TimecodeKit
 extension Clip
 {
     func toAVAssetAndMapping(baseURL:URL? = nil) throws -> (asset:AVAsset, timeMaping:CMTimeMapping)?
@@ -17,7 +17,7 @@ extension Clip
         guard
             let externalReference = self.mediaReference as? ExternalReference,
             let asset = externalReference.toAVAsset(baseURL: baseURL),
-            let timeRangeInAsset = self.sourceRange?.toCMTimeRange()
+            var timeRangeInAsset = self.sourceRange?.toCMTimeRange()
         else
         {
             return nil
@@ -25,6 +25,12 @@ extension Clip
 
         let rangeInParent = try self.rangeInParent().toCMTimeRange()
 
+        // if we have timecode from our asset
+        if let timecodeCMTime = try asset.startTimecode()?.cmTimeValue
+        {
+            timeRangeInAsset = CMTimeRange(start: timeRangeInAsset.start - timecodeCMTime, duration: timeRangeInAsset.duration )
+        }
+        
         return (asset, CMTimeMapping(source: timeRangeInAsset, target:rangeInParent))
     }
 }

--- a/Sources/OpenTimelineIO-AVFoundation/OpenTimelineIO-Extensions/Timeline.swift
+++ b/Sources/OpenTimelineIO-AVFoundation/OpenTimelineIO-Extensions/Timeline.swift
@@ -39,13 +39,15 @@ public extension Timeline
 
         for track in self.videoTracks
         {
+            let compositionVideoTrack = composition.addMutableTrack(withMediaType: .video, preferredTrackID: kCMPersistentTrackID_Invalid)
+
             for child in track.children
             {
                 guard
                     let clip = child as? Clip,
                     let (sourceAsset, clipTimeMapping) = try clip.toAVAssetAndMapping(baseURL: baseURL),
                     let sourceAssetFirstVideoTrack = try await sourceAsset.loadTracks(withMediaType: .video).first,
-                    let compositionVideoTrack = composition.mutableTrack(compatibleWith: sourceAssetFirstVideoTrack) ?? composition.addMutableTrack(withMediaType: .video, preferredTrackID: kCMPersistentTrackID_Invalid)
+                    let compositionVideoTrack = compositionVideoTrack //composition.mutableTrack(compatibleWith: sourceAssetFirstVideoTrack) ??
                 else
                 {
                     // TODO: GAP !?
@@ -53,16 +55,22 @@ public extension Timeline
                 }
                 
                 // Handle Timing
-                var trackTimeRange = clipTimeMapping.target
-                var sourceAssetTimeRange = clipTimeMapping.source
-                
-//                // Handle global time offset
-//                if let globalStartCMTime = globalStartCMTime
-//                {
-//                    trackTimeRange = CMTimeRange(start: trackTimeRange.start - globalStartCMTime, duration: trackTimeRange.duration)
-//                }
-                
-                try compositionVideoTrack.insertTimeRange(sourceAssetTimeRange, of: sourceAssetFirstVideoTrack, at: trackTimeRange.start)
+                let trackTimeRange = clipTimeMapping.target
+                let sourceAssetTimeRange = clipTimeMapping.source
+                   
+                // We attempt to re-use a track per OTIO track, but we may have CMFormatDesc inconsistencies which means insertion will fails
+                // If so - we make a new one
+                do
+                {
+                    try compositionVideoTrack.insertTimeRange(sourceAssetTimeRange, of: sourceAssetFirstVideoTrack, at: trackTimeRange.start)
+                }
+                catch
+                {
+                    if let compositionVideoTrack = composition.mutableTrack(compatibleWith: sourceAssetFirstVideoTrack) ?? composition.addMutableTrack(withMediaType: .video, preferredTrackID: kCMPersistentTrackID_Invalid)
+                    {
+                        try compositionVideoTrack.insertTimeRange(sourceAssetTimeRange, of: sourceAssetFirstVideoTrack, at: trackTimeRange.start)
+                    }
+                }
                 
                 // Support Time Scaling
                 let unscaledTrackTime = CMTimeRangeMake(start: trackTimeRange.start, duration: sourceAssetTimeRange.duration)
@@ -89,13 +97,15 @@ public extension Timeline
         
         for track in self.audioTracks
         {
+            let compositionAudioTrack = composition.addMutableTrack(withMediaType: .audio, preferredTrackID: kCMPersistentTrackID_Invalid)
+
             for child in track.children
             {
                 guard
                     let clip = child as? Clip,
                     let (sourceAsset, clipTimeMapping) = try clip.toAVAssetAndMapping(baseURL: baseURL),
                     let sourceAssetFirstAudioTrack = try await sourceAsset.loadTracks(withMediaType: .audio).first,
-                    let compositionAudioTrack = composition.mutableTrack(compatibleWith: sourceAssetFirstAudioTrack) ?? composition.addMutableTrack(withMediaType: .audio, preferredTrackID: kCMPersistentTrackID_Invalid)
+                    let compositionAudioTrack = compositionAudioTrack
                 else
                 {
                     // TODO: GAP !?
@@ -105,7 +115,20 @@ public extension Timeline
                 // Handle Timing
                 let trackTimeRange = clipTimeMapping.target
                 let sourceAssetTimeRange = clipTimeMapping.source
-                try compositionAudioTrack.insertTimeRange(sourceAssetTimeRange, of: sourceAssetFirstAudioTrack, at: trackTimeRange.start)
+                
+                // We attempt to re-use a track per OTIO track, but we may have CMFormatDesc inconsistencies which means insertion will fails
+                // If so - we make a new one
+                do
+                {
+                    try compositionAudioTrack.insertTimeRange(sourceAssetTimeRange, of: sourceAssetFirstAudioTrack, at: trackTimeRange.start)
+                }
+                catch
+                {
+                    if let compositionAudioTrack = composition.mutableTrack(compatibleWith: sourceAssetFirstAudioTrack) ?? composition.addMutableTrack(withMediaType: .audio, preferredTrackID: kCMPersistentTrackID_Invalid)
+                    {
+                        try compositionAudioTrack.insertTimeRange(sourceAssetTimeRange, of: sourceAssetFirstAudioTrack, at: trackTimeRange.start)
+                    }
+                }
                 
                 compositionAudioTrack.isEnabled = try await sourceAssetFirstAudioTrack.load(.isEnabled)
 

--- a/Sources/OpenTimelineIO-AVFoundation/OpenTimelineIO-Extensions/Timeline.swift
+++ b/Sources/OpenTimelineIO-AVFoundation/OpenTimelineIO-Extensions/Timeline.swift
@@ -93,7 +93,7 @@ public extension Timeline
             {
                 guard
                     let clip = child as? Clip,
-                    let (sourceAsset, clipTimeMapping) = try clip.toAVAssetAndMapping(),
+                    let (sourceAsset, clipTimeMapping) = try clip.toAVAssetAndMapping(baseURL: baseURL),
                     let sourceAssetFirstAudioTrack = try await sourceAsset.loadTracks(withMediaType: .audio).first,
                     let compositionAudioTrack = composition.mutableTrack(compatibleWith: sourceAssetFirstAudioTrack) ?? composition.addMutableTrack(withMediaType: .audio, preferredTrackID: kCMPersistentTrackID_Invalid)
                 else


### PR DESCRIPTION
Todo:

* Validate that OTIO files with global offset times and asset times which assume time-coded times generate valid compositions
* validate that assets with timecode in the composition create OTIO files with expected timecode offset RationalTime / Time Ranges (?) 